### PR TITLE
tools/snap: simplify nproc

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -425,7 +425,7 @@ To build utilizing the same options as Kata, you should make use of the `configu
 $ cd $your_qemu_directory
 $ $packaging_dir/scripts/configure-hypervisor.sh kata-qemu > kata.cfg
 $ eval ./configure "$(cat kata.cfg)"
-$ make -j $(nproc)
+$ make -j $(nproc --ignore=1)
 $ sudo -E make install
 ```
 

--- a/docs/use-cases/using-Intel-QAT-and-kata.md
+++ b/docs/use-cases/using-Intel-QAT-and-kata.md
@@ -279,8 +279,8 @@ $ export KERNEL_EXTRAVERSION=$(awk '/^EXTRAVERSION =/{print $NF}' $GOPATH/$LINUX
 $ export KERNEL_ROOTFS_DIR=${KERNEL_MAJOR_VERSION}.${KERNEL_PATHLEVEL}.${KERNEL_SUBLEVEL}${KERNEL_EXTRAVERSION}
 $ cd $QAT_SRC
 $ KERNEL_SOURCE_ROOT=$GOPATH/$LINUX_VER ./configure --enable-icp-sriov=guest
-$ sudo -E make all -j$(nproc)
-$ sudo -E make INSTALL_MOD_PATH=$ROOTFS_DIR qat-driver-install -j$(nproc)
+$ sudo -E make all -j $($(nproc ${CI:+--ignore 1}))
+$ sudo -E make INSTALL_MOD_PATH=$ROOTFS_DIR qat-driver-install -j $($(nproc ${CI:+--ignore 1}))
 ```
 
 The `usdm_drv` module also needs to be copied into the rootfs modules path and

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,7 +193,7 @@ parts:
       # Setup and build kernel
       ./build-kernel.sh -v "${kernel_version}" -d setup
       cd ${kernel_dir_prefix}*
-      make -j $(($(nproc)-1)) EXTRAVERSION=".container"
+      make -j $(nproc ${CI:+--ignore 1}) EXTRAVERSION=".container"
 
       kernel_suffix="${kernel_version}.container"
       kata_kernel_dir="${SNAPCRAFT_PART_INSTALL}/usr/share/kata-containers"
@@ -282,7 +282,7 @@ parts:
       esac
 
       # build and install
-      make -j $(($(nproc)-1))
+      make -j $(nproc ${CI:+--ignore 1})
       make install DESTDIR="${SNAPCRAFT_PART_INSTALL}"
     prime:
       - -snap/

--- a/tools/osbuilder/dockerfiles/QAT/run.sh
+++ b/tools/osbuilder/dockerfiles/QAT/run.sh
@@ -90,14 +90,14 @@ build_qat_drivers()
     KERNEL_ROOTFS_DIR=${KERNEL_MAJOR_VERSION}.${KERNEL_PATHLEVEL}.${KERNEL_SUBLEVEL}${KERNEL_EXTRAVERSION}
     cd $QAT_SRC
     KERNEL_SOURCE_ROOT=${linux_kernel_path} ./configure ${QAT_CONFIGURE_OPTIONS}
-    make all -j$(nproc) 
+    make all -j $($(nproc ${CI:+--ignore 1})) 
 }
 
 add_qat_to_rootfs()
 {
     /bin/echo -e "\n\e[1;42mCopy driver modules to rootfs\e[0m"
     cd $QAT_SRC
-    sudo -E make INSTALL_MOD_PATH=${ROOTFS_DIR} qat-driver-install -j$(nproc)
+    sudo -E make INSTALL_MOD_PATH=${ROOTFS_DIR} qat-driver-install -j$(nproc --ignore=1)
     sudo cp $QAT_SRC/build/usdm_drv.ko ${ROOTFS_DIR}/lib/modules/${KERNEL_ROOTFS_DIR}/updates/drivers
     sudo depmod -a -b ${ROOTFS_DIR} ${KERNEL_ROOTFS_DIR}
     cd ${kata_repo_path}/tools/osbuilder/image-builder

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -19,7 +19,7 @@ $(MK_DIR)/dockerbuild/install_yq.sh:
 	$(MK_DIR)/kata-deploy-copy-yq-installer.sh
 
 all-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
-	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) V=
+	${MAKE} -f $(MK_PATH) all -j $(shell nproc ${CI:+--ignore 1}) V=
 
 all: cloud-hypervisor-tarball \
 	firecracker-tarball \

--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -418,9 +418,9 @@ build_kernel() {
 	[ -n "${arch_target}" ] || arch_target="$(uname -m)"
 	arch_target=$(arch_to_kernel "${arch_target}")
 	pushd "${kernel_path}" >>/dev/null
-	make -j $(nproc) ARCH="${arch_target}"
+	make -j $(nproc ${CI:+--ignore 1}) ARCH="${arch_target}"
 	if [ "${conf_guest}" == "sev" ]; then
-		make -j $(nproc --ignore=1) INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=${kernel_path} modules_install
+		make -j $(nproc ${CI:+--ignore 1}) INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=${kernel_path} modules_install
 	fi
 	[ "$arch_target" != "powerpc" ] && ([ -e "arch/${arch_target}/boot/bzImage" ] || [ -e "arch/${arch_target}/boot/Image.gz" ])
 	[ -e "vmlinux" ]

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -74,6 +74,6 @@ RUN git clone --depth=1 "${QEMU_REPO}" qemu && \
     /root/patch_qemu.sh "${QEMU_VERSION}" "/root/kata_qemu/patches" && \
     (PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s "kata-qemu${BUILD_SUFFIX}" | xargs ./configure \
 	--with-pkgversion="kata-static${BUILD_SUFFIX}") && \
-    make -j"$(nproc)" && \
+    make -j"$(nproc ${CI:+--ignore 1})" && \
     make install DESTDIR="${QEMU_DESTDIR}" && \
     /root/static-build/scripts/qemu-build-post.sh


### PR DESCRIPTION
Replaces calls of nproc	with nproc with

nproc ${CI:+--ignore 1}

to run nproc with one less processing unit than the maximum to prevent
DOS-ing the local machine.

If process is being run in a container (determined via whether $CI is
null), all processing units avaliable will be used.

Fixes #3967

Signed-off-by: Derek Lee <derlee@redhat.com>