### PR TITLE
wip: github-actions: Add cargo-deny to GHA

### DIFF
--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,0 +1,34 @@
+name: Check 
+on: [pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+        tomls: [./src/agent/Cargo.toml,
+                ./src/agent/rustjail/Cargo.toml,
+                ./src/agent/vsock-exporter/Cargo.toml,
+                ./src/libs/Cargo.toml,
+                ./src/libs/logging/Cargo.toml,
+                ./src/libs/oci/Cargo.toml,
+                ./src/libs/protocols/Cargo.toml,
+                ./src/libs/safe-path/Cargo.toml,
+                ./src/tools/agent-ctl/Cargo.toml,
+                ./src/tools/runk/libcontainer/Cargo.toml,
+                ./src/tools/runk/Cargo.toml,
+                ./src/tools/trace-forwarder/Cargo.toml]
+
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - name: "Checkout code"
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
+      uses: actions/checkout@v2
+    - name: "Check Rust Licenses"
+      uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
+        entrypoint: ${{ matrix.tomls }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,64 @@
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+]
+
+[advisories]
+vulnerability = "deny"
+unsound = "deny"
+unmaintained = "deny"
+ignore = []
+
+[bans]
+multiple-versions = "deny"
+deny = [
+    # You can never be too sure
+    { name = "openssl-sys" },
+    # crates should use cc, not big separate build systems
+    { name = "cmake" },
+]
+skip = []
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+allow = ["Apache-2.0", "MIT", "BSD-3-Clause", "ISC"]
+
+exceptions = [
+    # ring uses code from multiple libraries but all with permissive licenses
+    # https://tldrlegal.com/license/openssl-license-(openssl)
+    { allow = ["ISC", "MIT", "OpenSSL"], name = "ring" },
+
+    # MPL 2.0 is a copyleft license and we HAVE to disclose
+    # the source code of these specific libraries if we do changes to it.
+    # which we do through public forks of the repos if/when we do changes to it.
+    # https://tldrlegal.com/license/mozilla-public-license-2.0-(mpl-2)
+    { allow = ["MPL-2.0"], name = "webpki-roots" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
+
+[[licenses.clarify]]
+name = "encoding_rs"
+expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+license-files = [{ path = "COPYRIGHT", hash = 0x39f8ad31 }]


### PR DESCRIPTION
Adds cargo-deny, a package that detects bad cargo packages, as a GitHub
Action.

Signed-off-by: Derek Lee <derlee@redhat.com>