### PR TITLE
agent/wip: Replace String with OsString or Path

### DIFF
--- a/src/agent/rustjail/src/cgroups/mock.rs
+++ b/src/agent/rustjail/src/cgroups/mock.rs
@@ -12,13 +12,14 @@ use cgroups::freezer::FreezerState;
 use libc::{self, pid_t};
 use oci::LinuxResources;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::string::String;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Manager {
     pub paths: HashMap<String, String>,
     pub mounts: HashMap<String, String>,
-    pub cpath: String,
+    pub cpath: PathBuf,
 }
 
 impl CgroupManager for Manager {
@@ -56,11 +57,11 @@ impl CgroupManager for Manager {
 }
 
 impl Manager {
-    pub fn new(cpath: &str) -> Result<Self> {
+    pub fn new(cpath: &PathBuf) -> Result<Self> {
         Ok(Self {
             paths: HashMap::new(),
             mounts: HashMap::new(),
-            cpath: cpath.to_string(),
+            cpath: cpath.to_path_buf(),
         })
     }
 

--- a/src/agent/rustjail/src/console.rs
+++ b/src/agent/rustjail/src/console.rs
@@ -11,7 +11,7 @@ use nix::unistd::{self, dup2};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 
-pub fn setup_console_socket(csocket_path: &str) -> Result<Option<RawFd>> {
+pub fn setup_console_socket(csocket_path: &Path) -> Result<Option<RawFd>> {
     if csocket_path.is_empty() {
         return Ok(None);
     }
@@ -25,7 +25,7 @@ pub fn setup_console_socket(csocket_path: &str) -> Result<Option<RawFd>> {
 
     match socket::connect(
         socket_fd,
-        &socket::SockAddr::Unix(socket::UnixAddr::new(Path::new(csocket_path))?),
+        &socket::SockAddr::Unix(socket::UnixAddr::new(csocket_path)?),
     ) {
         Ok(()) => Ok(Some(socket_fd)),
         Err(errno) => Err(anyhow!("failed to open console fd: {}", errno)),
@@ -72,7 +72,7 @@ mod tests {
 
         let _listener = UnixListener::bind(&socket_path).unwrap();
 
-        let ret = setup_console_socket(socket_path.to_str().unwrap());
+        let ret = setup_console_socket(socket_path.as_os_str());
 
         assert!(ret.is_ok());
     }

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -232,13 +232,13 @@ pub trait BaseContainer {
 #[derive(Debug)]
 pub struct LinuxContainer {
     pub id: String,
-    pub root: String,
+    pub root: PathBuf,
     pub config: Config,
     pub cgroup_manager: Option<FsManager>,
     pub init_process_pid: pid_t,
     pub init_process_start_time: u64,
-    pub uid_map_path: String,
-    pub gid_map_path: String,
+    pub uid_map_path: PathBuf,
+    pub gid_map_path: PathBuf,
     pub processes: HashMap<pid_t, Process>,
     pub status: ContainerStatus,
     pub created: SystemTime,
@@ -253,9 +253,9 @@ pub struct State {
     #[serde(default)]
     rootless: bool,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    cgroup_paths: HashMap<String, String>,
+    cgroup_paths: HashMap<String, PathBuf>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    namespace_paths: HashMap<NamespaceType, String>,
+    namespace_paths: HashMap<NamespaceType, PathBuf>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     external_descriptors: Vec<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -388,7 +388,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     let cm: FsManager = serde_json::from_str(cm_str)?;
 
     #[cfg(feature = "standard-oci-runtime")]
-    let csocket_fd = console::setup_console_socket(&std::env::var(CONSOLE_SOCKET_FD)?)?;
+    let csocket_fd = console::setup_console_socket(Path::new(&std::env::var(CONSOLE_SOCKET_FD)?))?;
 
     let p = if spec.process.is_some() {
         spec.process.as_ref().unwrap()
@@ -539,7 +539,6 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     let rootfs = spec.root.as_ref().unwrap().path.as_str();
     log_child!(cfd_log, "setup rootfs {}", rootfs);
     let root = fs::canonicalize(rootfs)?;
-    let rootfs = root.to_str().unwrap();
 
     if to_new.contains(CloneFlags::CLONE_NEWNS) {
         // setup rootfs
@@ -561,10 +560,10 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     if to_new.contains(CloneFlags::CLONE_NEWNS) {
         // unistd::chroot(rootfs)?;
         if no_pivot {
-            mount::ms_move_root(rootfs)?;
+            mount::ms_move_root(&root)?;
         } else {
             // pivot root
-            mount::pivot_rootfs(rootfs)?;
+            mount::pivot_rootfs(&root)?;
         }
 
         // setup sysctl
@@ -855,20 +854,16 @@ impl BaseContainer for LinuxContainer {
     async fn start(&mut self, mut p: Process) -> Result<()> {
         let logger = self.logger.new(o!("eid" => p.exec_id.clone()));
         let tty = p.tty;
-        let fifo_file = format!("{}/{}", &self.root, EXEC_FIFO_FILENAME);
+        let fifo_file = &self.root.join(EXEC_FIFO_FILENAME);
         info!(logger, "enter container.start!");
         let mut fifofd: RawFd = -1;
         if p.init {
-            if stat::stat(fifo_file.as_str()).is_ok() {
+            if stat::stat(fifo_file).is_ok() {
                 return Err(anyhow!("exec fifo exists"));
             }
-            unistd::mkfifo(fifo_file.as_str(), Mode::from_bits(0o644).unwrap())?;
+            unistd::mkfifo(fifo_file, Mode::from_bits(0o644).unwrap())?;
 
-            fifofd = fcntl::open(
-                fifo_file.as_str(),
-                OFlag::O_PATH,
-                Mode::from_bits(0).unwrap(),
-            )?;
+            fifofd = fcntl::open(fifo_file, OFlag::O_PATH, Mode::from_bits(0).unwrap())?;
         }
         info!(logger, "exec fifo opened!");
 
@@ -950,7 +945,7 @@ impl BaseContainer for LinuxContainer {
         let mut child = std::process::Command::new(exec_path);
 
         #[allow(unused_mut)]
-        let mut console_name = PathBuf::from("");
+        let mut console_name = PathBuf::new();
         #[cfg(feature = "standard-oci-runtime")]
         if !self.console_socket.as_os_str().is_empty() {
             console_name = self.console_socket.clone();
@@ -1108,8 +1103,8 @@ impl BaseContainer for LinuxContainer {
     }
 
     async fn exec(&mut self) -> Result<()> {
-        let fifo = format!("{}/{}", &self.root, EXEC_FIFO_FILENAME);
-        let fd = fcntl::open(fifo.as_str(), OFlag::O_WRONLY, Mode::from_bits_truncate(0))?;
+        let fifo = &self.root.join(EXEC_FIFO_FILENAME);
+        let fd = fcntl::open(fifo, OFlag::O_WRONLY, Mode::from_bits_truncate(0))?;
         let data: &[u8] = &[0];
         unistd::write(fd, data)?;
         info!(self.logger, "container started");
@@ -1318,12 +1313,12 @@ async fn join_namespaces(
         // setup uid/gid mappings
         write_mappings(
             &logger,
-            &format!("/proc/{}/uid_map", p.pid),
+            &Path::new(&format!("/proc/{}/uid_map", p.pid)),
             &linux.uid_mappings,
         )?;
         write_mappings(
             &logger,
-            &format!("/proc/{}/gid_map", p.pid),
+            &Path::new(&format!("/proc/{}/gid_map", p.pid)),
             &linux.gid_mappings,
         )?;
     }
@@ -1368,7 +1363,7 @@ async fn join_namespaces(
     Ok(())
 }
 
-fn write_mappings(logger: &Logger, path: &str, maps: &[LinuxIdMapping]) -> Result<()> {
+fn write_mappings(logger: &Logger, path: &Path, maps: &[LinuxIdMapping]) -> Result<()> {
     let data = maps
         .iter()
         .filter(|m| m.size != 0)
@@ -1419,25 +1414,21 @@ impl LinuxContainer {
     ) -> Result<Self> {
         let base = base.into();
         let id = id.into();
-        let root = format!("{}/{}", base.as_str(), id.as_str());
+        let root = Path::new(base.as_str()).join(id.as_str());
 
         // validate oci spec
         validator::validate(&config)?;
 
-        fs::create_dir_all(root.as_str()).map_err(|e| {
+        fs::create_dir_all(&root).map_err(|e| {
             if e.kind() == std::io::ErrorKind::AlreadyExists {
                 return anyhow!(e).context(format!("container {} already exists", id.as_str()));
             }
 
-            anyhow!(e).context(format!("fail to create container directory {}", root))
+            anyhow!(e).context(format!("fail to create container directory {:?}", root))
         })?;
 
-        unistd::chown(
-            root.as_str(),
-            Some(unistd::getuid()),
-            Some(unistd::getgid()),
-        )
-        .context(format!("cannot change onwer of container {} root", id))?;
+        unistd::chown(&root, Some(unistd::getuid()), Some(unistd::getgid()))
+            .context(format!("cannot change onwer of container {} root", id))?;
 
         if config.spec.is_none() {
             return Err(anyhow!(nix::Error::EINVAL));
@@ -1452,12 +1443,12 @@ impl LinuxContainer {
         let linux = spec.linux.as_ref().unwrap();
 
         let cpath = if linux.cgroups_path.is_empty() {
-            format!("/{}", id.as_str())
+            Path::new("/").join(&id)
         } else {
-            linux.cgroups_path.clone()
+            PathBuf::from(&linux.cgroups_path)
         };
 
-        let cgroup_manager = FsManager::new(cpath.as_str())?;
+        let cgroup_manager = FsManager::new(&cpath)?;
         info!(logger, "new cgroup_manager {:?}", &cgroup_manager);
 
         Ok(LinuxContainer {
@@ -1465,8 +1456,8 @@ impl LinuxContainer {
             root,
             cgroup_manager: Some(cgroup_manager),
             status: ContainerStatus::new(),
-            uid_map_path: String::from(""),
-            gid_map_path: "".to_string(),
+            uid_map_path: PathBuf::new(),
+            gid_map_path: PathBuf::new(),
             config,
             processes: HashMap::new(),
             created: SystemTime::now(),
@@ -1942,7 +1933,7 @@ mod tests {
     #[test]
     fn test_linuxcontainer_pause() {
         let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
-            c.cgroup_manager = FsManager::new("").ok();
+            c.cgroup_manager = FsManager::new(&PathBuf::new()).ok();
             c.pause().map_err(|e| anyhow!(e))
         });
 
@@ -1975,7 +1966,7 @@ mod tests {
     #[test]
     fn test_linuxcontainer_resume() {
         let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
-            c.cgroup_manager = FsManager::new("").ok();
+            c.cgroup_manager = FsManager::new(&PathBuf::new()).ok();
             // Change status to paused, this way we can resume it
             c.status.transition(ContainerState::Paused);
             c.resume().map_err(|e| anyhow!(e))

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -7,6 +7,7 @@
 
 #[cfg(target_arch = "aarch64")]
 use std::fs;
+use std::path::PathBuf;
 
 pub const SYSFS_DIR: &str = "/sys";
 #[cfg(any(
@@ -15,22 +16,22 @@ pub const SYSFS_DIR: &str = "/sys";
     target_arch = "x86_64",
     target_arch = "x86"
 ))]
-pub fn create_pci_root_bus_path() -> String {
-    String::from("/devices/pci0000:00")
+pub fn create_pci_root_bus_path() -> PathBuf {
+    PathBuf::from("/devices/pci0000:00")
 }
 
 #[cfg(target_arch = "aarch64")]
-pub fn create_pci_root_bus_path() -> String {
-    let ret = String::from("/devices/platform/4010000000.pcie/pci0000:00");
+pub fn create_pci_root_bus_path() -> PathBuf {
+    let ret = PathBuf::from("/devices/platform/4010000000.pcie/pci0000:00");
 
-    let acpi_root_bus_path = String::from("/devices/pci0000:00");
-    let mut acpi_sysfs_dir = String::from(SYSFS_DIR);
-    let mut sysfs_dir = String::from(SYSFS_DIR);
-    let mut start_root_bus_path = String::from("/devices/platform/");
-    let end_root_bus_path = String::from("/pci0000:00");
+    let acpi_root_bus_path = PathBuf::from("/devices/pci0000:00");
+    let mut acpi_sysfs_dir = PathBuf::from(SYSFS_DIR);
+    let mut sysfs_dir = PathBuf::from(SYSFS_DIR);
+    let mut start_root_bus_path = PathBuf::from("/devices/platform/");
+    let end_root_bus_path = PathBuf::from("/pci0000:00");
 
     // check if there is pci bus path for acpi
-    acpi_sysfs_dir.push_str(&acpi_root_bus_path);
+    acpi_sysfs_dir = acpi_sysfs_dir.join(&acpi_root_bus_path);
     if let Ok(_) = fs::metadata(&acpi_sysfs_dir) {
         return acpi_root_bus_path;
     }
@@ -46,17 +47,17 @@ pub fn create_pci_root_bus_path() -> String {
             Err(_) => return ret,
         };
         let dir_name = match pathname.file_name() {
-            Some(p) => p.to_str(),
+            Some(p) => p.to_os_str(),
             None => return ret,
         };
         let dir_name = match dir_name {
             Some(p) => p,
             None => return ret,
         };
-        let dir_name = String::from(dir_name);
+        let dir_name = OsString::from(dir_name);
         if dir_name.ends_with(".pcie") {
-            start_root_bus_path.push_str(&dir_name);
-            start_root_bus_path.push_str(&end_root_bus_path);
+            start_root_bus_path.join(&dir_name);
+            start_root_bus_path.join(&end_root_bus_path);
             return start_root_bus_path;
         }
     }
@@ -65,8 +66,8 @@ pub fn create_pci_root_bus_path() -> String {
 }
 
 #[cfg(target_arch = "s390x")]
-pub fn create_ccw_root_bus_path() -> String {
-    String::from("/devices/css0")
+pub fn create_ccw_root_bus_path() -> PathBuf {
+    PathBuf::from("/devices/css0")
 }
 // From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
 // The Linux kernel's core ACPI subsystem creates struct acpi_device

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -186,6 +186,8 @@ impl fmt::Debug for NamespaceType {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::{Namespace, NamespaceType};
     use crate::{mount::remove_mounts, skip_if_not_root};
     use nix::sched::CloneFlags;
@@ -205,7 +207,7 @@ mod tests {
             .await;
 
         assert!(ns_ipc.is_ok());
-        assert!(remove_mounts(&[ns_ipc.unwrap().path]).is_ok());
+        assert!(remove_mounts(&[&PathBuf::from(ns_ipc.unwrap().path)]).is_ok());
 
         let logger = slog::Logger::root(slog::Discard, o!());
         let tmpdir = Builder::new().prefix("uts").tempdir().unwrap();
@@ -217,7 +219,7 @@ mod tests {
             .await;
 
         assert!(ns_uts.is_ok());
-        assert!(remove_mounts(&[ns_uts.unwrap().path]).is_ok());
+        assert!(remove_mounts(&[&PathBuf::from(ns_uts.unwrap().path)]).is_ok());
 
         // Check it cannot persist pid namespaces.
         let logger = slog::Logger::root(slog::Discard, o!());

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -302,14 +302,14 @@ impl AgentService {
             let mounts = sandbox.container_mounts.get(&cid);
             if let Some(mounts) = mounts {
                 for m in mounts.iter() {
-                    if sandbox.storages.get(m).is_some() {
+                    if sandbox.storages.get(&PathBuf::from(m)).is_some() {
                         cmounts.push(m.to_string());
                     }
                 }
             }
 
             for m in cmounts.iter() {
-                sandbox.unset_and_remove_sandbox_storage(m)?;
+                sandbox.unset_and_remove_sandbox_storage(&PathBuf::from(m))?;
             }
 
             sandbox.container_mounts.remove(cid.as_str());

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -24,7 +24,7 @@ use slog::Logger;
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{thread, time};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
@@ -50,7 +50,7 @@ pub struct Sandbox {
     pub shared_utsns: Namespace,
     pub shared_ipcns: Namespace,
     pub sandbox_pidns: Option<Namespace>,
-    pub storages: HashMap<String, u32>,
+    pub storages: HashMap<PathBuf, u32>,
     pub running: bool,
     pub no_pivot_root: bool,
     pub sender: Option<tokio::sync::oneshot::Sender<i32>>,
@@ -105,10 +105,10 @@ impl Sandbox {
     // It's assumed that caller is calling this method after
     // acquiring a lock on sandbox.
     #[instrument]
-    pub fn set_sandbox_storage(&mut self, path: &str) -> bool {
+    pub fn set_sandbox_storage(&mut self, path: &PathBuf) -> bool {
         match self.storages.get_mut(path) {
             None => {
-                self.storages.insert(path.to_string(), 1);
+                self.storages.insert(path.to_path_buf(), 1);
                 true
             }
             Some(count) => {
@@ -128,9 +128,12 @@ impl Sandbox {
     // It's assumed that caller is calling this method after
     // acquiring a lock on sandbox.
     #[instrument]
-    pub fn unset_sandbox_storage(&mut self, path: &str) -> Result<bool> {
+    pub fn unset_sandbox_storage(&mut self, path: &PathBuf) -> Result<bool> {
         match self.storages.get_mut(path) {
-            None => Err(anyhow!("Sandbox storage with path {} not found", path)),
+            None => Err(anyhow!(
+                "Sandbox storage with path {} not found",
+                path.display()
+            )),
             Some(count) => {
                 *count -= 1;
                 if *count < 1 {
@@ -148,14 +151,19 @@ impl Sandbox {
     // It's assumed that caller is calling this method after
     // acquiring a lock on sandbox.
     #[instrument]
-    pub fn remove_sandbox_storage(&self, path: &str) -> Result<()> {
-        let mounts = vec![path.to_string()];
+    pub fn remove_sandbox_storage(&self, path: &Path) -> Result<()> {
+        let mounts = vec![path];
         remove_mounts(&mounts)?;
         // "remove_dir" will fail if the mount point is backed by a read-only filesystem.
         // This is the case with the device mapper snapshotter, where we mount the block device directly
         // at the underlying sandbox path which was provided from the base RO kataShared path from the host.
         if let Err(err) = fs::remove_dir(path) {
-            warn!(self.logger, "failed to remove dir {}, {:?}", path, err);
+            warn!(
+                self.logger,
+                "failed to remove dir {}, {:?}",
+                path.display(),
+                err
+            );
         }
         Ok(())
     }
@@ -167,9 +175,9 @@ impl Sandbox {
     // It's assumed that caller is calling this method after
     // acquiring a lock on sandbox.
     #[instrument]
-    pub fn unset_and_remove_sandbox_storage(&mut self, path: &str) -> Result<()> {
+    pub fn unset_and_remove_sandbox_storage(&mut self, path: &PathBuf) -> Result<()> {
         if self.unset_sandbox_storage(path)? {
-            return self.remove_sandbox_storage(path);
+            return self.remove_sandbox_storage(&path);
         }
 
         Ok(())
@@ -485,10 +493,7 @@ mod tests {
     use std::path::Path;
     use tempfile::{tempdir, Builder, TempDir};
 
-    fn bind_mount(src: &str, dst: &str, logger: &Logger) -> Result<(), Error> {
-        let src_path = Path::new(src);
-        let dst_path = Path::new(dst);
-
+    fn bind_mount(src_path: &Path, dst_path: &Path, logger: &Logger) -> Result<(), Error> {
         baremount(src_path, dst_path, "bind", MsFlags::MS_BIND, "", logger)
     }
 
@@ -501,13 +506,13 @@ mod tests {
         let mut s = Sandbox::new(&logger).unwrap();
 
         let tmpdir = Builder::new().tempdir().unwrap();
-        let tmpdir_path = tmpdir.path().to_str().unwrap();
+        let tmpdir_path = tmpdir.path().to_path_buf();
 
         // Add a new sandbox storage
-        let new_storage = s.set_sandbox_storage(tmpdir_path);
+        let new_storage = s.set_sandbox_storage(&tmpdir_path);
 
         // Check the reference counter
-        let ref_count = s.storages[tmpdir_path];
+        let ref_count = s.storages[&tmpdir_path];
         assert_eq!(
             ref_count, 1,
             "Invalid refcount, got {} expected 1.",
@@ -516,12 +521,12 @@ mod tests {
         assert!(new_storage);
 
         // Use the existing sandbox storage
-        let new_storage = s.set_sandbox_storage(tmpdir_path);
+        let new_storage = s.set_sandbox_storage(&tmpdir_path);
         assert!(!new_storage, "Should be false as already exists.");
 
         // Since we are using existing storage, the reference counter
         // should be 2 by now.
-        let ref_count = s.storages[tmpdir_path];
+        let ref_count = s.storages[&tmpdir_path];
         assert_eq!(
             ref_count, 2,
             "Invalid refcount, got {} expected 2.",
@@ -538,41 +543,42 @@ mod tests {
         let s = Sandbox::new(&logger).unwrap();
 
         let tmpdir = Builder::new().tempdir().unwrap();
-        let tmpdir_path = tmpdir.path().to_str().unwrap();
+        let tmpdir_path = tmpdir.path();
 
         let srcdir = Builder::new()
             .prefix("src")
             .tempdir_in(tmpdir_path)
             .unwrap();
-        let srcdir_path = srcdir.path().to_str().unwrap();
+        let srcdir_path = srcdir.path();
 
         let destdir = Builder::new()
             .prefix("dest")
-            .tempdir_in(tmpdir_path)
+            .tempdir_in(tmpdir_path.to_path_buf())
             .unwrap();
-        let destdir_path = destdir.path().to_str().unwrap();
+        let destdir_path = destdir.path();
 
         let emptydir = Builder::new()
             .prefix("empty")
-            .tempdir_in(tmpdir_path)
+            .tempdir_in(tmpdir_path.to_path_buf())
             .unwrap();
 
         assert!(
-            s.remove_sandbox_storage(srcdir_path).is_err(),
+            s.remove_sandbox_storage(&srcdir_path.to_path_buf())
+                .is_err(),
             "Expect Err as the directory is not a mountpoint"
         );
 
-        assert!(s.remove_sandbox_storage("").is_err());
+        assert!(s.remove_sandbox_storage(&PathBuf::new()).is_err());
 
         let invalid_dir = emptydir.path().join("invalid");
 
+        assert!(s.remove_sandbox_storage(&invalid_dir).is_err());
+
+        assert!(bind_mount(&srcdir_path, &destdir_path, &logger).is_ok());
+
         assert!(s
-            .remove_sandbox_storage(invalid_dir.to_str().unwrap())
-            .is_err());
-
-        assert!(bind_mount(srcdir_path, destdir_path, &logger).is_ok());
-
-        assert!(s.remove_sandbox_storage(destdir_path).is_ok());
+            .remove_sandbox_storage(&destdir_path.to_path_buf())
+            .is_ok());
     }
 
     #[tokio::test]
@@ -584,32 +590,32 @@ mod tests {
         let mut s = Sandbox::new(&logger).unwrap();
 
         assert!(
-            s.unset_and_remove_sandbox_storage("/tmp/testEphePath")
+            s.unset_and_remove_sandbox_storage(&PathBuf::from("/tmp/testEphePath"))
                 .is_err(),
             "Should fail because sandbox storage doesn't exist"
         );
 
         let tmpdir = Builder::new().tempdir().unwrap();
-        let tmpdir_path = tmpdir.path().to_str().unwrap();
+        let tmpdir_path = tmpdir.path();
 
         let srcdir = Builder::new()
             .prefix("src")
             .tempdir_in(tmpdir_path)
             .unwrap();
-        let srcdir_path = srcdir.path().to_str().unwrap();
+        let srcdir_path = srcdir.path();
 
         let destdir = Builder::new()
             .prefix("dest")
             .tempdir_in(tmpdir_path)
             .unwrap();
-        let destdir_path = destdir.path().to_str().unwrap();
+        let destdir_path = destdir.path().to_path_buf();
 
-        assert!(bind_mount(srcdir_path, destdir_path, &logger).is_ok());
+        assert!(bind_mount(&srcdir_path, &destdir_path, &logger).is_ok());
 
-        assert!(s.set_sandbox_storage(destdir_path));
-        assert!(s.unset_and_remove_sandbox_storage(destdir_path).is_ok());
+        assert!(s.set_sandbox_storage(&destdir_path));
+        assert!(s.unset_and_remove_sandbox_storage(&destdir_path).is_ok());
 
-        let other_dir_str;
+        let other_dir_path;
         {
             // Create another folder in a separate scope to ensure that is
             // deleted
@@ -617,13 +623,13 @@ mod tests {
                 .prefix("dir")
                 .tempdir_in(tmpdir_path)
                 .unwrap();
-            let other_dir_path = other_dir.path().to_str().unwrap();
-            other_dir_str = other_dir_path.to_string();
+            other_dir_path = other_dir.path().to_path_buf();
+            //other_dir_str = other_dir_path.as_os_str();
 
-            assert!(s.set_sandbox_storage(other_dir_path));
+            assert!(s.set_sandbox_storage(&other_dir_path));
         }
 
-        assert!(s.unset_and_remove_sandbox_storage(&other_dir_str).is_err());
+        assert!(s.unset_and_remove_sandbox_storage(&other_dir_path).is_err());
     }
 
     #[tokio::test]
@@ -632,23 +638,23 @@ mod tests {
         let logger = slog::Logger::root(slog::Discard, o!());
         let mut s = Sandbox::new(&logger).unwrap();
 
-        let storage_path = "/tmp/testEphe";
+        let storage_path = PathBuf::from("/tmp/testEphe");
 
         // Add a new sandbox storage
-        assert!(s.set_sandbox_storage(storage_path));
+        assert!(s.set_sandbox_storage(&storage_path));
         // Use the existing sandbox storage
         assert!(
-            !s.set_sandbox_storage(storage_path),
+            !s.set_sandbox_storage(&storage_path),
             "Expects false as the storage is not new."
         );
 
         assert!(
-            !s.unset_sandbox_storage(storage_path).unwrap(),
+            !s.unset_sandbox_storage(&storage_path).unwrap(),
             "Expects false as there is still a storage."
         );
 
         // Reference counter should decrement to 1.
-        let ref_count = s.storages[storage_path];
+        let ref_count = s.storages[&storage_path];
         assert_eq!(
             ref_count, 1,
             "Invalid refcount, got {} expected 1.",
@@ -656,7 +662,7 @@ mod tests {
         );
 
         assert!(
-            s.unset_sandbox_storage(storage_path).unwrap(),
+            s.unset_sandbox_storage(&storage_path).unwrap(),
             "Expects true as there is still a storage."
         );
 
@@ -664,15 +670,15 @@ mod tests {
         // there should not be any reference in sandbox struct
         // for the given storage
         assert!(
-            !s.storages.contains_key(storage_path),
+            !s.storages.contains_key(&storage_path),
             "The storages map should not contain the key {}",
-            storage_path
+            storage_path.display()
         );
 
         // If no container is using the sandbox storage, the reference
         // counter for it should not exist.
         assert!(
-            s.unset_sandbox_storage(storage_path).is_err(),
+            s.unset_sandbox_storage(&storage_path).is_err(),
             "Expects false as the reference counter should no exist."
         );
     }


### PR DESCRIPTION
To cover the edge case where paths may not be UTF-8 encoded, paths
should be type OsString or Path rather than String.

This replaces most instances of String with Path or OsString.

Signed-off-by: Derek Lee <derlee@redhat.com>